### PR TITLE
DELETE /projects/{id}の際のトークンの受取をRequestBodyに変更

### DIFF
--- a/src/main/kotlin/com/approvers/devlazaApi/controller/ProjectsController.kt
+++ b/src/main/kotlin/com/approvers/devlazaApi/controller/ProjectsController.kt
@@ -196,12 +196,12 @@ class ProjectsController(
     }
 
     @DeleteMapping("/{id}")
-    fun deleteProject(@PathVariable(value = "id", required = true) rawId: String, @RequestParam(name = "token", required = true) token: String): ResponseEntity<String> {
+    fun deleteProject(@PathVariable(value = "id", required = true) rawId: String, @RequestBody token: TokenPoster): ResponseEntity<String> {
         val projectId: UUID = rawId.toUUID()
 
         val project: Projects = getProject(projectId) ?: throw NotFound("Project not found")
 
-        val userIdFromToken: UUID = decode(token)
+        val userIdFromToken: UUID = decode(token.token)
 
         if (project.createdUserId == userIdFromToken) {
             projectsRepository.delete(project)

--- a/src/test/kotlin/com/approvers/devlazaApi/ProjectControllerTest.kt
+++ b/src/test/kotlin/com/approvers/devlazaApi/ProjectControllerTest.kt
@@ -124,7 +124,7 @@ class ProjectControllerTest(
         mockMvc.perform(
             delete("/projects/$projectIDCache")
                 .contentType(MediaType.APPLICATION_JSON)
-                .param("token", tokenCache)
+                .content(tokenJson)
         )
 
         mockMvc.perform(
@@ -250,40 +250,44 @@ class ProjectControllerTest(
             .andReturn()
         val project: Projects = mapper.readValue(result.response.contentAsString, Projects::class.java)
         val projectID: String = project.id!!.toString()
+        val tokenJson = generateTokenJson(tokenCache)
 
         mockMvc.perform(
             delete("/projects/$projectID")
                 .contentType(MediaType.APPLICATION_JSON)
-                .param("token", tokenCache)
+                .content(tokenJson)
         ).andExpect(status().isNoContent)
     }
 
     @Test
     fun failDeleteProjectWithProjectNotFound() {
         val invalidProjectID: String = UUID.randomUUID().toString()
+        val tokenJson = generateTokenJson(tokenCache)
         mockMvc.perform(
             delete("/projects/$invalidProjectID")
                 .contentType(MediaType.APPLICATION_JSON)
-                .param("token", tokenCache)
+                .content(tokenJson)
         ).andExpect(status().isNotFound)
     }
 
     @Test
     fun failDeleteProjectWithInvalidToken() {
         val invalidToken = "EGAGVAAWG.HRAWTGAW.HWEYHAZ"
+        val tokenJson = generateTokenJson(invalidToken)
         mockMvc.perform(
             delete("/projects/$projectIDCache")
                 .contentType(MediaType.APPLICATION_JSON)
-                .param("token", invalidToken)
+                .content(tokenJson)
         ).andExpect(status().isBadRequest)
     }
 
     @Test
     fun failDeleteProjectWithIsNotCreatedUser() {
+        val tokenJson = generateTokenJson(joinUserTokenCache)
         mockMvc.perform(
             delete("/projects/$projectIDCache")
                 .contentType(MediaType.APPLICATION_JSON)
-                .param("token", joinUserTokenCache)
+                .content(tokenJson)
         ).andExpect(status().isBadRequest)
     }
 

--- a/src/test/kotlin/com/approvers/devlazaApi/ProjectLeaveFailTest.kt
+++ b/src/test/kotlin/com/approvers/devlazaApi/ProjectLeaveFailTest.kt
@@ -126,6 +126,12 @@ class ProjectLeaveFailTest(
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(tokenJson)
         )
+
+        mockMvc.perform(
+            delete("/projects/$projectIDCache")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(tokenJson)
+        )
     }
 
     @Test


### PR DESCRIPTION
こんなカス実装をしていたのは誰ですか?
私です